### PR TITLE
feat: FindAllFiles, FindAllFilesExcept methods for ignoring .gitignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,19 +5,19 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        go-version: [~1.15, ^1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4.0.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Download Go modules
         run: go mod download

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,19 +5,19 @@ jobs:
   coverage:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [^1]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Coverage
         env:

--- a/gitcha_test.go
+++ b/gitcha_test.go
@@ -3,7 +3,6 @@ package gitcha
 import (
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 )
@@ -34,7 +33,7 @@ func TestGitRepoForPath(t *testing.T) {
 func TestFindAllFiles(t *testing.T) {
 	tmp := t.TempDir()
 
-	gitignore, err := os.Create(path.Join(tmp, ".gitignore"))
+	gitignore, err := os.Create(filepath.Join(tmp, ".gitignore"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gitcha_test.go
+++ b/gitcha_test.go
@@ -30,6 +30,40 @@ func TestGitRepoForPath(t *testing.T) {
 	}
 }
 
+func TestFindAllFiles(t *testing.T) {
+	tt := []struct {
+		path string
+		list []string
+		exp  string
+	}{
+		{".", []string{"*.test"}, "ignore.test"},
+	}
+
+	for _, test := range tt {
+		_, err := os.Create(test.exp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(test.exp)
+
+		ch, err := FindAllFiles(test.path, test.list)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for v := range ch {
+			var err error
+			test.exp, err = filepath.Abs(test.exp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.exp != v.Path {
+				t.Errorf("Expected %v, got %v for %s", test.exp, v, test.path)
+			}
+		}
+	}
+}
+
 func TestFindFiles(t *testing.T) {
 	tlink, err := tempLink(".")
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/muesli/gitcha
 
-go 1.14
+go 1.15
 
 require (
 	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94


### PR DESCRIPTION
This PR introduces two new methods:

* `FindAllFiles`
* `FindAllFilesExcept`

to allow ignoring .gitignore when applicable.
